### PR TITLE
Add test summary and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,20 @@ typecheck-tests:
 		exit 1; \
 	fi; \
 	echo "All test files type checked successfully via tests/tsconfig.json."
+
+# --- Test Summary ---
+.PHONY: test-summary
+
+# Summarize tests by tier
+test-summary:
+	@echo "Summarizing tests by tier:"
+	@for tier_dir in $(shell find tests -maxdepth 1 -type d -name 'tier*' | sort); do \
+		tier_name=$$(basename $$tier_dir); \
+		num_tests=$$(find $$tier_dir -type f -name '*.test.ts' | wc -l | tr -d ' '); \
+		if [ $$num_tests -gt 0 ]; then \
+			echo "  $${tier_name}: $$num_tests test file(s)"; \
+		else \
+			echo "  $${tier_name}: No test files found"; \
+		fi; \
+	done
+	@echo "For detailed test execution, run 'make test' or 'npm test'."

--- a/README.md
+++ b/README.md
@@ -3,3 +3,54 @@
 A VS Code extension for WYSIWYG editing of Pandoc Markdown.
 
 <!-- Test comment for pre-commit hook - attempt 2 -->
+
+## Getting Started
+
+Follow these instructions to get the Pandocora extension up and running on your local machine.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (which includes npm)
+- [Visual Studio Code](https://code.visualstudio.com/)
+
+### Installation and Running
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/your-username/pandocora.git
+    cd pandocora
+    ```
+    *(Replace `your-username` with the actual username or organization if this is a fork or a specific upstream)*
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Build the extension:**
+    ```bash
+    npm run build
+    ```
+
+4.  **Run the extension in VS Code:**
+    - Open the project folder (`pandocora`) in VS Code.
+    - Press `F5` to open a new Extension Development Host window with the Pandocora extension loaded.
+    - In the Extension Development Host window, open or create a Markdown file (`.md`) to activate the editor.
+
+**Quick Setup Bash Block:**
+
+```bash
+# Clone the repository (replace with the correct URL if needed)
+git clone https://github.com/your-username/pandocora.git
+cd pandocora
+
+# Install dependencies
+npm install
+
+# Build the extension
+npm run build
+
+# At this point, you can open the 'pandocora' directory in VS Code
+# and press F5 to launch the Extension Development Host.
+echo "Setup complete. Open the 'pandocora' directory in VS Code and press F5 to run the extension."
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,7 @@ The `Makefile` provides more granular control over the testing process.
 -   `make test-file file=<path_to_test_file.test.ts>`: Runs a specific test file.
     *Example:* `make test-file file=tests/tier0/compilation.test.ts`
 -   `make typecheck-tests`: Runs TypeScript type checking on all files within the `tests/` directory.
+-   `make test-summary`: Prints a summary of the number of test files in each tier. This is also available via `npm run test:summary`.
 
 ## Adding New Tests
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format": "prettier --write \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit",
-    "test": "make test"
+    "test": "make test",
+    "test:summary": "make test-summary"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
- Added a 'test:summary' script to package.json and a corresponding 'test-summary' target to the Makefile to display the number of test files per tier.
- Updated README.md with 'Getting Started' instructions, including a bash script for quick setup.
- Updated docs/testing.md to include the new test summary commands.